### PR TITLE
⚙️(workflows): Add GitHub App token generation for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,15 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -34,5 +40,5 @@ jobs:
         run: pnpm install
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: npx semantic-release


### PR DESCRIPTION
- Introduced `actions/create-github-app-token@v1` to generate a GitHub App token.
- Configured steps to use the newly generated GitHub App token.
- Updated checkout step to use the app-token for fetching repository data.
- Modified release step to use the app-token instead of the GitHub token.