### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/backend/src/apis/bund/nina/nina.service.ts
+++ b/backend/src/apis/bund/nina/nina.service.ts
@@ -66,6 +66,11 @@ export class NinaService {
    * @throws {Error} - If there is an error in the HTTP request or response.
    */
   public async fetchWarningDetails(warningId: string): Promise<any> {
+    // Validate the warningId to ensure it matches the expected format
+    const validIdPattern = /^[a-zA-Z0-9_-]+$/;
+    if (!validIdPattern.test(warningId)) {
+      throw new Error('Invalid warning ID format');
+    }
     const url = `${this.ninaWarningApi}/${warningId}.json`;
     try {
       const response = await fetch(url);


### PR DESCRIPTION
Fixes [https://github.com/rubenvitt/ember-rescue/security/code-scanning/1](https://github.com/rubenvitt/ember-rescue/security/code-scanning/1)

To fix the SSRF vulnerability, we need to validate and sanitize the `id` parameter before using it to construct the URL. One effective way to do this is to ensure that the `id` parameter matches a predefined pattern or set of allowed values. This can be achieved by using a regular expression or by checking against a list of known valid IDs.

1. **Validation**: Ensure that the `id` parameter conforms to a specific format (e.g., alphanumeric characters only).
2. **Sanitization**: Reject any `id` that does not match the expected format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
