### PR TITLE
✨(release-config): add GitHub release asset configuration

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,6 +16,14 @@
           "CHANGELOG.md"
         ]
       }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          "frontend/src-tauri/target/bundle/dmg/*.dmg"
+        ]
+      }
     ]
   ]
 }


### PR DESCRIPTION
- Added `@semantic-release/github` plugin for handling release assets.
- Specified DMG files from `frontend/src-tauri/target/bundle/dmg/*.dmg` as assets for GitHub releases.