### PR TITLE
chore(workflow): relocate listing of frontend artifacts in release wo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,15 +127,6 @@ jobs:
           projectPath: frontend
           args: ${{ matrix.args }}
 
-      - name: List frontend artifacts
-        run: |
-          echo "Listing contents of frontend-artifacts directory:"
-          find frontend-artifacts -type d
-          echo "Listing all .dmg, .AppImage, and .msi files:"
-          find frontend-artifacts -type f \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.msi" \)
-          echo "Listing contents of src-tauri/target directory:"
-          find frontend-artifacts -type d -name "src-tauri" -exec find {}/target -type f \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.msi" \) \;
-
       - name: Upload Frontend Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -172,6 +163,15 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: frontend-artifacts
+
+      - name: List frontend artifacts
+        run: |
+          echo "Listing contents of frontend-artifacts directory:"
+          find frontend-artifacts -type d
+          echo "Listing all .dmg, .AppImage, and .msi files:"
+          find frontend-artifacts -type f \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.msi" \)
+          echo "Listing contents of src-tauri/target directory:"
+          find frontend-artifacts -type d -name "src-tauri" -exec find {}/target -type f \( -name "*.dmg" -o -name "*.AppImage" -o -name "*.msi" \) \;
 
       - name: Prepare Release Notes
         run: |


### PR DESCRIPTION
…rkflow

- Moved 'List frontend artifacts' step to a new position in the release workflow.
- Ensures artifact listing happens before uploading frontend artifacts and generating release notes.