### PR TITLE
chore(workflows): correct artifact upload path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: frontend-artifact-${{ matrix.platform }}
-          path: frontend/src-tauri/target/release/bundle
+          path: frontend/src-tauri/target
 
   release:
     name: Create Release


### PR DESCRIPTION
- Changed artifact upload path from `frontend/src-tauri/target/release/bundle` to `frontend/src-tauri/target` in the release workflow to ensure correct files are uploaded.
