### PR TITLE
🧹(release): configure semantic-release to publish frontend artifacts …

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -8,7 +8,7 @@ module.exports = {
         releaseRules: {
           major: ['💥'],
           minor: ['✨'],
-          patch: ['🐛', '🚑', '🔒'],
+          patch: ['🐛', '🚑', '🔒', '🧹'],
         },
         releaseNotes: {
           template: `{{#if compareUrl}}
@@ -120,16 +120,17 @@ WIP Änderungen:
         message: '🔖 chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],
-    // [
-    //   '@semantic-release/github',
-    //   {
-    //     assets: [
-    //       'CHANGELOG.md',
-    //       'frontend-artifacts/**/*.dmg',
-    //       'frontend-artifacts/**/*.AppImage',
-    //       'frontend-artifacts/**/*.msi',
-    //     ],
-    //   },
-    // ],
+    [
+      '@semantic-release/github',
+      {
+        assets: [
+          'CHANGELOG.md',
+          'frontend/src-tauri/target/release/**/*.dmg',
+          'frontend/src-tauri/target/release/**/*.AppImage',
+          'frontend/src-tauri/target/release/**/*.msi',
+        ],
+        releaseAssets: true,
+      },
+    ],
   ],
 };

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,4 +44,4 @@ COPY --from=build /usr/src/app/dist ./dist
 EXPOSE 3000
 
 # Anwendung starten
-CMD ["pnpm", "start:migrate:prod"]
+CMD ["pnpm", "start:prod"]


### PR DESCRIPTION
…and update backend start command

- Updated `.releaserc.js` to include frontend Tauri release artifacts (dmg, AppImage, msi)
- Enabled `releaseAssets` in GitHub release configuration
- Modified backend Dockerfile to use `pnpm start:prod` instead of `pnpm start:migrate:prod`

No breaking changes introduced.