### PR TITLE
🔧 Simplify Windows release version extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,28 +127,25 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          # Function to convert version
-          function Convert-Version {
+          # Function to get only major.minor.patch
+          function Get-BaseVersion {
               param($version)
-              if ($version -match '-alpha\.(\d+)') {
-                  $alphaNum = [int]$matches[1]
-                  $alphaNum = [Math]::Min($alphaNum, 65535)
-                  return $version -replace '-alpha\.\d+', ".$alphaNum"
-              } else {
-                  return $version -replace '-.*', '.0'
+              if ($version -match '(\d+\.\d+\.\d+)') {
+                  return $matches[1]
               }
+              return $version
           }
 
           # Update tauri.conf.json
           $tauriContent = Get-Content frontend/src-tauri/tauri.conf.json -Raw
           $tauriJson = $tauriContent | ConvertFrom-Json
-          $tauriJson.version = Convert-Version $tauriJson.version
+          $tauriJson.version = Get-BaseVersion $tauriJson.version
           $tauriJson | ConvertTo-Json -Depth 32 | Set-Content frontend/src-tauri/tauri.conf.json
 
           # Update package.json
           $packageContent = Get-Content frontend/package.json -Raw
           $packageJson = $packageContent | ConvertFrom-Json
-          $packageJson.version = Convert-Version $packageJson.version
+          $packageJson.version = Get-BaseVersion $packageJson.version
           $packageJson | ConvertTo-Json -Depth 32 | Set-Content frontend/package.json
 
       - name: Build Tauri


### PR DESCRIPTION
- Replaced complex version conversion with a simpler base version extraction
- Modified `Convert-Version` function to `Get-BaseVersion`
- Extracts only major.minor.patch version for Tauri and package configurations
- Reduces complexity of version handling in release workflow