### PR TITLE
Fix-build

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -115,7 +115,6 @@ WIP Änderungen:
         },
       },
     ],
-    '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     [
       '@semantic-release/changelog',
@@ -146,7 +145,7 @@ WIP Änderungen:
           'shared/package.json',
           'RELEASE.md'
         ],
-        message: '🔖 chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+        message: '🔖(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },
     ],
     [


### PR DESCRIPTION
- Removed '@semantic-release/commit-analyzer' plugin
- Simplified release commit message format
- Minor adjustments to release configuration structure